### PR TITLE
Fix time difference for delivery to be positive if it is late

### DIFF
--- a/typescript/src/deliveryController.ts
+++ b/typescript/src/deliveryController.ts
@@ -36,7 +36,7 @@ export class DeliveryController {
             const delivery = this.#deliveries[i];
             if (delivery.id === event.id) {
                 delivery.arrived = true;
-                var timeDifference = delivery.timeOfDelivery.getTime() - event.timeOfDelivery.getTime();
+                var timeDifference = event.timeOfDelivery.getTime() - delivery.timeOfDelivery.getTime();
                 if (timeDifference < TEN_MINUTES) {
                     delivery.onTime = true;
                 }


### PR DESCRIPTION
Minor fix to typescript as the time difference was calculated differently to other languages:
The [CSharp](https://github.com/emilybache/DeliveryController-Refactoring-Kata/blob/4256641c5c03812befcf94de9f2effe870496420/csharp/DeliveryController/DeliveryController.cs#L29) has
`                    var timeDifference = deliveryEvent.TimeOfDelivery - delivery.TimeOfDelivery;`
Whereas the [Typescript](https://github.com/emilybache/DeliveryController-Refactoring-Kata/blob/main/typescript/src/deliveryController.ts) has it the other way:
`                var timeDifference = delivery.timeOfDelivery.getTime() - event.timeOfDelivery.getTime();`
This means you only get to be not on time if you are more than ten minutes early. This pr switches the calculation to be in the same order as the CSharp.